### PR TITLE
Fix selection background color

### DIFF
--- a/src/make-theme/index.js
+++ b/src/make-theme/index.js
@@ -9,6 +9,7 @@ export const makeTheme = (theme) => {
         theme.tokenColors.find((token) => token.scope === "support").settings
           .foreground,
       backgroundColor: theme.colors["editor.background"],
+      selectionBackground: theme.colors["editor.selectionBackground"],
     },
     ...prismTheme,
   };

--- a/src/make-theme/template.js
+++ b/src/make-theme/template.js
@@ -28,7 +28,7 @@ pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection {
   text-shadow: none;
-  background: ${theme.plain.backgroundColor};
+  background: ${theme.plain.selectionBackground};
 }
 
 pre[class*="language-"]::selection,
@@ -36,7 +36,7 @@ pre[class*="language-"] ::selection,
 code[class*="language-"]::selection,
 code[class*="language-"] ::selection {
   text-shadow: none;
-  background: ${theme.plain.backgroundColor};
+  background: ${theme.plain.selectionBackground};
 }
 
 @media print {


### PR DESCRIPTION
Currently, when selecting code selection is the same color as the background and is not visible. Solution: take the same selection color as in VSCode editor.